### PR TITLE
fix bigwig track when a bin contains 0 coverage

### DIFF
--- a/genomeview/graphtrack.py
+++ b/genomeview/graphtrack.py
@@ -122,9 +122,10 @@ class BigWigTrack(GraphTrack):
         chrom = match_chrom_format(scale.chrom, self.bigwig.chroms().keys())
 
         for i in range(scale.start, scale.end, binsize):
-            values = self.bigwig.stats(chrom, i, i+binsize)
+            value = self.bigwig.stats(chrom, i, i+binsize)[0]
+            value = 0.0 if value==None else value
             x.append(i+binsize/2)
-            y.append(values[0])
+            y.append(value)
         
         self.series = {"vals":Series(x, y, color="black")}
         


### PR DESCRIPTION
pybigwig returns `[None]` from `bigwig.stats()` if the interval contains no coverage.
Added a line to account for this and stop bigwig track from breaking due to None-types instead of 0s.